### PR TITLE
Fixed some stuff up, mostly formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Web Programming Final Project, Spring 2024
 
-Alex Foundain  
+Alex Fountain  
 Santino Navaroli  
 Daniel Romero  
 Aiden Tobin

--- a/calendar.html
+++ b/calendar.html
@@ -15,7 +15,7 @@
 </div>
 <div id="calendar">
     <iframe src="https://calendar.google.com/calendar/embed?src=17ae5dd8cb3b5ff033e43ce312aa7e19e1f3ac8dc3926f553235985af1a7f403%40group.calendar.google.com&ctz=America%2FNew_York"
-            style="border: 0" width="800" height="600" frameborder="0" scrolling="no"></iframe>
+            style="border: 0" width="800" height="600"></iframe>
 </div>
 </body>
 </html>

--- a/calendar.html
+++ b/calendar.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <script src="res/base.js"></script>
     <link rel="stylesheet" href="res/base.css">
+    <link rel="stylesheet" href="res/calendar.css">
     <link rel="icon" href="res/UNG-Icon.jpg">
     <title>Calendar</title>
 </head>
@@ -12,10 +13,9 @@
 <div>
     <header id="header"></header>
 </div>
-<div>
-    <p align="center">
-        <iframe src="https://calendar.google.com/calendar/embed?src=17ae5dd8cb3b5ff033e43ce312aa7e19e1f3ac8dc3926f553235985af1a7f403%40group.calendar.google.com&ctz=America%2FNew_York"
-                style="border: 0" width="800" height="600" frameborder="0" scrolling="no"></iframe>
+<div id="calendar">
+    <iframe src="https://calendar.google.com/calendar/embed?src=17ae5dd8cb3b5ff033e43ce312aa7e19e1f3ac8dc3926f553235985af1a7f403%40group.calendar.google.com&ctz=America%2FNew_York"
+            style="border: 0" width="800" height="600" frameborder="0" scrolling="no"></iframe>
 </div>
 </body>
 </html>

--- a/res/base.css
+++ b/res/base.css
@@ -35,13 +35,6 @@ header a:hover {
     color: black;
 }
 
-#siteName {
-    background-color: blue;
-    text-align: center;
-    padding-top: 10px;
-    color: white;
-}
-
 #headericon {
     height: 1em;
 }

--- a/res/base.css
+++ b/res/base.css
@@ -22,6 +22,9 @@ header a:hover {
     flex-direction: row;
     flex-wrap: wrap;
     justify-content: space-evenly;
+}
+
+#menu {
     background: linear-gradient(white, whitesmoke);
     padding-top: 10px;
     padding-bottom: 10px;

--- a/res/base.css
+++ b/res/base.css
@@ -2,6 +2,11 @@ body {
     margin: 0;
 }
 
+p, h1, h2, h3 {
+    margin-left: 0.2in;
+    margin-right: 0.2in;
+}
+
 header {
     font-size: 3vh;
     font-family: Verdana serif;

--- a/res/calendar.css
+++ b/res/calendar.css
@@ -1,0 +1,4 @@
+#calendar {
+    justify-content: center;
+    display: flex;
+}


### PR DESCRIPTION
- Moved the CSS code for the header into its own ID to clear some things up.
- Restored the side margins on the text that were removed when we removed the browser's default margins.
- Removed some obsolete HTML attributes on the Google Calendar iframe regarding frameborder and scrolling
- Removed the center aligning paragraph holding the calendar in the middle and replaced it with a display: flex and justify-content: center
- Fixed Alex's last name (I definitely made that README in a rush)
- Removed the siteName selector that was previously being used for the "North Georgia Astronomical Observatory" that was now going unused.